### PR TITLE
feat(cms): add manual retry task with maxAgeHours override

### DIFF
--- a/cms/src/domains/points/trigger/retry-stale-push-requests.ts
+++ b/cms/src/domains/points/trigger/retry-stale-push-requests.ts
@@ -1,7 +1,61 @@
-import { schedules, tasks } from "@trigger.dev/sdk"
+import { schedules, task, tasks } from "@trigger.dev/sdk"
 import { getPayloadInstance } from "@/payload"
 import { PUSH_REQUEST_STATUS } from "../types"
 import type { processPushRequest } from "./process-push-request"
+
+const MIN_AGE_MINUTES = 15
+const DEFAULT_MAX_AGE_HOURS = 2
+const MAX_AGE_HOURS_CAP = 168 // 7 days
+
+function clampMaxAgeHours(input: number | undefined): number {
+	if (input === undefined || !Number.isFinite(input) || input <= 0) return DEFAULT_MAX_AGE_HOURS
+	return Math.min(input, MAX_AGE_HOURS_CAP)
+}
+
+async function runRetryStaleRequests({ maxAgeHours }: { maxAgeHours: number }) {
+	console.log(`Checking for stale push requests (maxAgeHours=${maxAgeHours})...`)
+
+	const db = await getPayloadInstance()
+	const now = new Date()
+	const minAgeCutoff = new Date(now.getTime() - MIN_AGE_MINUTES * 60 * 1000)
+	const maxAgeCutoff = new Date(now.getTime() - maxAgeHours * 60 * 60 * 1000)
+
+	const staleRequests = await db.find({
+		collection: "push-requests",
+		where: {
+			and: [
+				{ status: { not_equals: PUSH_REQUEST_STATUS.COMPLETED } },
+				{ createdAt: { less_than: minAgeCutoff.toISOString() } },
+				{ createdAt: { greater_than: maxAgeCutoff.toISOString() } },
+			],
+		},
+		limit: 100,
+		depth: 0,
+	})
+
+	if (staleRequests.docs.length === 0) {
+		console.log("No stale push requests found")
+		return { retriggered: 0, total: 0, maxAgeHours }
+	}
+
+	console.log(`Found ${staleRequests.docs.length} stale push requests`)
+
+	let retriggeredCount = 0
+	for (const request of staleRequests.docs) {
+		try {
+			await tasks.trigger<typeof processPushRequest>("process-push-request", {
+				pushRequestId: request.id,
+			})
+			retriggeredCount++
+			console.log(`Retriggered push request ${request.id}`)
+		} catch (error) {
+			console.error(`Failed to retrigger push request ${request.id}:`, error)
+		}
+	}
+
+	console.log(`Retriggered ${retriggeredCount} stale push requests`)
+	return { retriggered: retriggeredCount, total: staleRequests.docs.length, maxAgeHours }
+}
 
 /**
  * CRON job to retry stale push requests.
@@ -17,49 +71,19 @@ export const retryStaleRequests = schedules.task({
 	retry: {
 		maxAttempts: 3,
 	},
-	run: async () => {
-		console.log("Checking for stale push requests...")
+	run: async () => runRetryStaleRequests({ maxAgeHours: DEFAULT_MAX_AGE_HOURS }),
+})
 
-		const db = await getPayloadInstance()
-		const now = new Date()
-		const fifteenMinutesAgo = new Date(now.getTime() - 15 * 60 * 1000)
-		const twoHoursAgo = new Date(now.getTime() - 2 * 60 * 60 * 1000)
-
-		// Find stale push requests
-		const staleRequests = await db.find({
-			collection: "push-requests",
-			where: {
-				and: [
-					{ status: { not_equals: PUSH_REQUEST_STATUS.COMPLETED } },
-					{ createdAt: { less_than: fifteenMinutesAgo.toISOString() } },
-					{ createdAt: { greater_than: twoHoursAgo.toISOString() } },
-				],
-			},
-			limit: 100, // Process max 100 at a time
-			depth: 0,
-		})
-
-		if (staleRequests.docs.length === 0) {
-			console.log("No stale push requests found")
-			return { retriggered: 0 }
-		}
-
-		console.log(`Found ${staleRequests.docs.length} stale push requests`)
-
-		let retriggeredCount = 0
-		for (const request of staleRequests.docs) {
-			try {
-				await tasks.trigger<typeof processPushRequest>("process-push-request", {
-					pushRequestId: request.id,
-				})
-				retriggeredCount++
-				console.log(`Retriggered push request ${request.id}`)
-			} catch (error) {
-				console.error(`Failed to retrigger push request ${request.id}:`, error)
-			}
-		}
-
-		console.log(`Retriggered ${retriggeredCount} stale push requests`)
-		return { retriggered: retriggeredCount, total: staleRequests.docs.length }
+/**
+ * Manually-invocable version of the retry job.
+ * Accepts an optional `maxAgeHours` to widen the lookback beyond the default 2h,
+ * clamped to 168h (7 days). The 15-minute minimum age is not configurable.
+ */
+export const retryStaleRequestsManual = task({
+	id: "retry-stale-push-requests-manual",
+	retry: {
+		maxAttempts: 3,
 	},
+	run: async (payload: { maxAgeHours?: number } = {}) =>
+		runRetryStaleRequests({ maxAgeHours: clampMaxAgeHours(payload.maxAgeHours) }),
 })


### PR DESCRIPTION
Add a manually-invocable trigger.dev task (`retry-stale-push-requests-manual`) that accepts an optional `maxAgeHours` payload, letting operators widen the lookback window when push requests have been stuck longer than the hourly cron's fixed 2h upper bound (e.g. after an outage, paused deploy, or latent bug).

The value is clamped to 168h (7 days); non-finite or non-positive values fall back to the 2h default. The existing scheduled task keeps its id (`retry-stale-push-requests`), cron, and 2h default — both tasks delegate to a single shared helper so behavior stays in lockstep. The 15-minute minimum age stays fixed and is not configurable.

Invocation is dashboard-only — no new admin API endpoint. `schedules.task` in trigger.dev v4 has a fixed payload shape, so a separate regular `task` is the clean way to accept custom params without disturbing the registered schedule.

### Manual dashboard payloads

- `{}` → 2h (matches current scheduled behavior)
- `{ "maxAgeHours": 72 }` → 72h lookback
- `{ "maxAgeHours": 10000 }` → clamped to 168h

Effective `maxAgeHours` is logged on every run.