### PR TITLE
fix(ci): remove invalid --access flag from changeset:publish

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
 	"scripts": {
 		"build": "turbo build",
 		"changeset": "changeset",
-		"changeset:publish": "pnpm build --filter=@sfpro/sdk && changeset publish --access public",
+		"changeset:publish": "pnpm build --filter=@sfpro/sdk && changeset publish",
 		"changeset:version": "changeset version",
 		"check": "biome check --write .",
 		"check:ci": "biome check --write --no-errors-on-unmatched .",


### PR DESCRIPTION
## Problem

The release workflow (`changesets/action@v1`) failed at the publish step:

```
🦋  error Unknown flag for publish: --access
🦋  error Usage: changeset publish [--tag <name>] [--otp <code>] [--no-git-tag]
 ELIFECYCLE  Command failed with exit code 1.
```

The root `changeset:publish` script passed `--access public` to `changeset publish`. That flag belongs to `npm publish`, not `changeset publish` — so the command aborted on argument parsing before any package was published. (The SDK build itself succeeded; the failure was purely the bad flag.)

## Fix

Remove `--access public` from the script. Public access is already configured in two places, so the flag was both invalid and redundant:

- `.changeset/config.json` → `"access": "public"`
- `sdk/package/package.json` → `"publishConfig": { "access": "public" }`

`@changesets/cli` resolves access as `publishConfig.access || config.access` and builds the `--access` arg for the underlying `npm publish` itself, so removing it from the script changes nothing about the published access level.

OIDC trusted publishing (`No NPM_TOKEN found, but OIDC is available`) is unaffected — the run never reached the auth stage.

## Verification

- `changeset publish --help` confirms only `--tag`, `--otp`, `--no-git-tag` are accepted.
- Re-run the release workflow; the publish step should now reach OIDC trusted-publishing auth and publish `@sfpro/sdk` publicly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)